### PR TITLE
Drop weights issue

### DIFF
--- a/tests/test_sampc.py
+++ b/tests/test_sampc.py
@@ -2,6 +2,8 @@
 import numpy as np
 import numpy.ma as ma
 import pytest
+from ustat_var.generate_test_data import generate_unique_nan_arrays
+from ustat_var.generate_test_data import generate_data
 from ustat_var.sampc import sampc
 
 
@@ -66,3 +68,40 @@ def test_sampc_no_valid_pairs():
     
     # Test within tolerance
     np.testing.assert_allclose(result, expected, rtol=1e-6)
+
+
+def test_sampc_very_few_valid_pairs():
+    '''Test the sampc helper function when some rows have no valid pairs. 
+    Should return 0s for those rows, and should equal the sample covariance for other rows invalid rows are removed'''
+    
+    # Array parameters
+    n_teachers, n_time = 100, 50
+
+    # Set seed
+    np.random.seed(131)
+    
+    # Generate arrays
+    for i in range(1000):  # Test multiple times 
+
+        # Generate arrays (high probability of single product pair)
+        nanA, nanB = generate_unique_nan_arrays(n_rows=n_teachers, n_cols=n_time, n_arrays=2,
+                                        min_int=1, max_int=2, nan_prob=0.8, balanced = True)
+        A, B = generate_data(n_teachers=n_teachers, n_time=n_time, n_arrays=2, cov_factor=1)
+        A = nanA * A
+        B = nanB * B
+
+        Acounts = np.count_nonzero(~np.isnan(A),1)  # No. of valid obs in A
+        Bcounts = np.count_nonzero(~np.isnan(B),1)  # No. of valid obs in B
+        ABcounts = np.count_nonzero(~np.isnan(A * B),1)   # No. of valid obs in both A and B
+        nproducts = (Acounts*Bcounts - ABcounts) # No. of valid product pairs
+        check = np.any(nproducts == 0)  
+        if not check:
+            continue  # Try again if all rows have valid pairs
+
+        # Expect to return all 0s when no valid pairs.
+        expected = sampc(A[ABcounts>1],B[Bcounts>1])  # Should handle internally
+        result = sampc(A,B)
+        result = result[ABcounts>1]  # Only compare valid rows
+
+        # Test within tolerance
+        np.testing.assert_allclose(result, expected, rtol=1e-6)

--- a/tests/test_sampc.py
+++ b/tests/test_sampc.py
@@ -48,7 +48,7 @@ def test_sampc_some_nans():
     
 
 def test_sampc_no_valid_pairs():
-    '''Test the sampc helper function on a simple case with some NaNs'''
+    '''Test the sampc helper function when there are no valid pairs. Should return 0s.'''
     
     # Test arrays
     X = np.array([

--- a/tests/test_sampc.py
+++ b/tests/test_sampc.py
@@ -85,7 +85,7 @@ def test_sampc_very_few_valid_pairs():
 
         # Generate arrays (high probability of single product pair)
         nanA, nanB = generate_unique_nan_arrays(n_rows=n_teachers, n_cols=n_time, n_arrays=2,
-                                        min_int=1, max_int=2, nan_prob=0.8, balanced = True)
+                                        min_int=1, max_int=2, nan_prob=0.6, balanced = True)
         A, B = generate_data(n_teachers=n_teachers, n_time=n_time, n_arrays=2, cov_factor=1)
         A = nanA * A
         B = nanB * B

--- a/tests/test_ustat_samp_covar.py
+++ b/tests/test_ustat_samp_covar.py
@@ -115,3 +115,39 @@ def test_samp_covar_weighted():
     unweighted = ustat_samp_covar_fast(A,B,C,D)
     weighted = ustat_samp_covar_fast(A,B,C,D,w=weights)
     np.testing.assert_allclose(weighted, unweighted, rtol=1e-6)
+
+
+def test_samp_covar_drop_prod_pairs():
+    '''Test ustat_samp_covar in case when a row contains only one observation'''
+    
+    # Arrays to test
+    A = np.array([
+        [1.0, 2.0, np.nan],
+        [4.0, np.nan, np.nan],
+        [3.0, 2.0, 1.0]
+    ])
+    B = np.array([
+        [1.0, 2.0, 3.0],
+        [6.0, np.nan, np.nan],
+        [64.0, 8.0, 1.0]
+    ])
+    
+    # Remove second row, these will be removed from the calculations
+    A_filt = np.delete(A, 1, axis=0)
+    B_filt = np.delete(B, 1, axis=0)
+    
+    # Create weights
+    weights = np.ones(A.shape[0])
+    weights_filt = np.delete(weights, 1)
+    
+    # Calculate sampling variances
+    unweighted = ustat_samp_covar_fast(A, B, A, B)
+    unweighted_filt = ustat_samp_covar_fast(A_filt, B_filt, A_filt, B_filt)
+    weighted = ustat_samp_covar_fast(A, B, A, B, w=weights)
+    weighted_filt = ustat_samp_covar_fast(A_filt, B_filt, A_filt, B_filt, w=weights_filt)
+
+    
+    # Test equality
+    np.testing.assert_allclose(weighted, unweighted, rtol=1e-6)
+    np.testing.assert_allclose(unweighted_filt, unweighted, rtol=1e-6)
+    np.testing.assert_allclose(weighted_filt, weighted, rtol=1e-6)

--- a/tests/test_ustat_samp_covar.py
+++ b/tests/test_ustat_samp_covar.py
@@ -69,8 +69,12 @@ def test_ustat_samp_covar_sym_unbalanced():
 def test_fast_samp_covar():
     ''' Test that the fast and slow versions of ustat_samp_covar give the same results '''
     
+    # Test parameters
+    n_rows = 100
+    n_cols = 50
+    
     # (Fixed) random arrays to test
-    A, B, C, D = generate_unique_nan_arrays(n_rows = 100, n_cols = 50, n_arrays = 4,
+    A, B, C, D = generate_unique_nan_arrays(n_rows = n_rows, n_cols = n_cols, n_arrays = 4,
                                             min_int=1, max_int = 100, nan_prob = 0.25, seed = 14378,
                                             balanced = False)
     
@@ -93,3 +97,21 @@ def test_fast_samp_covar():
     np.testing.assert_allclose(slow_AABB, fast_AABB, rtol=1e-6)
     np.testing.assert_allclose(slow_AAAA, fast_AAAA, rtol=1e-6)
     np.testing.assert_allclose(slow_ABAB, fast_ABAB, rtol=1e-6)
+
+
+def test_samp_covar_weighted():
+    ''' Test that the fast and slow versions of ustat_samp_covar give the same results '''
+    
+    # Test parameters
+    n_rows = 100
+    n_cols = 50
+    np.random.seed(83194)
+    
+    # (Fixed) random arrays to test
+    A, B, C, D = generate_unique_nan_arrays(n_rows = n_rows, n_cols = n_cols, n_arrays = 4,
+                                            min_int=1, max_int = 100, nan_prob = 0.25, seed = 14378,
+                                            balanced = False)
+    weights = np.ones(n_rows)
+    unweighted = ustat_samp_covar_fast(A,B,C,D)
+    weighted = ustat_samp_covar_fast(A,B,C,D,w=weights)
+    np.testing.assert_allclose(weighted, unweighted, rtol=1e-6)

--- a/tests/test_varcovar.py
+++ b/tests/test_varcovar.py
@@ -119,7 +119,8 @@ def test_varcovar_sum():
         
         # Generate arrays
         nanA, nanB = generate_unique_nan_arrays(n_rows=n_teachers, n_cols=n_time, n_arrays=2,
-                                       min_int=1, max_int=2, nan_prob=0.25, balanced = False)
+                                       min_int=1, max_int=2, nan_prob=0.25, balanced = True)
+        
         A, B = generate_data(n_teachers=n_teachers, n_time=n_time, n_arrays=2, cov_factor=1)
         A = nanA * A
         B = nanB * B
@@ -172,7 +173,7 @@ def test_varcovar_balanced_works():
     np.testing.assert_allclose(varC, varC_result, rtol=1e-6)
     
     
-def test_single_prod_pair_drops():
+def test_prod_pair_drops():
     '''test that function drops single observations properly'''
     
     # Array parameters

--- a/tests/test_varcovar.py
+++ b/tests/test_varcovar.py
@@ -23,11 +23,6 @@ def test_varcovar_weights_simple():
     
     # Weights to test
     w_row = np.array([5, 5, 5])
-    w_panel = np.array([
-        [10, 10, 10],
-        [10, 10, 10],
-        [10, 10, 10]
-    ])
     
     # Results to test
     unweighted = varcovar(origX = A, origY = B)
@@ -51,7 +46,6 @@ def test_varcovar_weights_unbalanced():
     
     # Weights to test
     w_row = np.array(np.repeat(5, n_teachers))
-    w_panel = np.array(np.repeat(10, n_teachers * n_time)).reshape(n_teachers, n_time)
     
     # Results to test
     unweighted = varcovar(A, B)
@@ -176,3 +170,7 @@ def test_varcovar_balanced_works():
     # Test equality
     np.testing.assert_allclose(covAB, covAB_result, rtol=1e-6)
     np.testing.assert_allclose(varC, varC_result, rtol=1e-6)
+    
+    
+def test_single_prod_pair_drops():
+    '''test that function drops single observations properly'''

--- a/tests/test_varcovar.py
+++ b/tests/test_varcovar.py
@@ -27,9 +27,7 @@ def test_varcovar_weights_simple():
     # Results to test
     unweighted = varcovar(origX = A, origY = B)
     teacher_weighted = varcovar(origX=A, origY=B, w=w_row)
-    
-    # Expected result
-    
+
     
     # Test equality
     np.testing.assert_allclose(unweighted, teacher_weighted, rtol=1e-6)
@@ -41,8 +39,7 @@ def test_varcovar_weights_unbalanced():
     # Arrays to test
     n_teachers, n_time = 50, 10
     A, B = generate_unique_nan_arrays(n_rows=n_teachers, n_cols=n_time, n_arrays=2,
-                                      min_int=1, max_int=9, nan_prob=0.25, seed = 48912,
-                                      balanced = False)
+                                      min_int=1, max_int=9, nan_prob=0.25, balanced = False)
     
     # Weights to test
     w_row = np.array(np.repeat(5, n_teachers))
@@ -97,7 +94,7 @@ def test_varcovar_scale_var():
     for i in range(100):
         
         A = generate_unique_nan_arrays(n_rows=n_teachers, n_cols=n_time, n_arrays=1,
-                                      min_int=1, max_int=9, nan_prob=0.25, seed = 48912, balanced = False)[0]
+                                      min_int=1, max_int=9, nan_prob=0.25, balanced = False)[0]
         k = np.random.randint(1, 100)
         B = k * A
         
@@ -121,10 +118,13 @@ def test_varcovar_sum():
     for i in range(100):
         
         # Generate arrays
-        A,B = generate_unique_nan_arrays(n_rows=n_teachers, n_cols=n_time, n_arrays=2,
-                                      min_int=1, max_int=9, nan_prob=0.25, seed = 48912,
-                                         balanced = False)
+        nanA, nanB = generate_unique_nan_arrays(n_rows=n_teachers, n_cols=n_time, n_arrays=2,
+                                       min_int=1, max_int=2, nan_prob=0.25, balanced = False)
+        A, B = generate_data(n_teachers=n_teachers, n_time=n_time, n_arrays=2, cov_factor=1)
+        A = nanA * A
+        B = nanB * B
         C = A + B
+  
         
         # Calculate required variances/covariances
         varA = varcovar(A, A)
@@ -174,3 +174,57 @@ def test_varcovar_balanced_works():
     
 def test_single_prod_pair_drops():
     '''test that function drops single observations properly'''
+    
+    # Array parameters
+    n_teachers, n_time = 500, 50
+    
+    # Set seed
+    np.random.seed(131)
+    
+    # Test 100 times
+    for i in range(100):
+        
+        # Generate arrays (high probability of single product pair)
+        nanA, nanB = generate_unique_nan_arrays(n_rows=n_teachers, n_cols=n_time, n_arrays=2,
+                                       min_int=1, max_int=2, nan_prob=0.80, balanced = False)
+        
+        # Check if nan arrays generated single product pairs
+        countsX = np.count_nonzero(~np.isnan(nanA),1)  # No. of obs in X
+        countsY = np.count_nonzero(~np.isnan(nanB),1)  # No. of obs in Y
+        nsquares = np.count_nonzero(~np.isnan(nanA * nanB),1)   # No. of obs in both X and Y
+        nproducts = (countsX*countsY - nsquares) # No. of valid product pairs        
+        check = np.any(nproducts == 0)
+        
+        # If some rows have no products pairs, generate data
+        if (check):
+            A, B = generate_data(n_teachers=n_teachers, n_time=n_time, n_arrays=2, cov_factor=1)
+            A = nanA * A
+            B = nanB * B
+            
+            # A and B with single product pair rows removed
+            A_filt = A[nproducts>0,:].copy()
+            B_filt = B[nproducts>0,:].copy()
+
+            # Generate weights
+            w_rand = np.random.exponential(scale = 1, size = n_teachers)
+            w_ones = np.ones(n_teachers)
+            
+            # Calc variance-covariance objects
+            covAB_equal_weights = varcovar(A,B,w=w_ones)
+            covAB_unweighted = varcovar(A,B)
+            covAB_exp_weights = varcovar(A,B,w_rand)
+            covAB_filt_exp_weights = varcovar(A_filt, B_filt, w_rand[nproducts>0])
+            
+            # Test equality
+            np.testing.assert_allclose(covAB_unweighted, covAB_equal_weights, rtol=1e-6)
+            np.testing.assert_allclose(covAB_exp_weights, covAB_filt_exp_weights, rtol=1e-6)
+
+        # If the random arrays didn't generate single product pair rows, then skip this iteration.
+        else:
+            continue
+        
+        
+        
+        
+        
+    

--- a/ustat_var/generate_test_data.py
+++ b/ustat_var/generate_test_data.py
@@ -73,9 +73,6 @@ def generate_unique_nan_arrays(n_rows, n_cols, n_arrays, nan_prob, min_int, max_
     return arrays
 
 
-
-import numpy as np
-
 def generate_data(n_teachers, n_time, n_arrays, var_fixed=1.0, var_noise=1.0, cov_factor=0.5, seed=None):
     """
     Generates n_arrays arrays of size (n_teachers, n_time), all with fixed variance and covariance structure.

--- a/ustat_var/lamb_sum.py
+++ b/ustat_var/lamb_sum.py
@@ -32,12 +32,17 @@ def lamb_sum(X,C_jjX,C_jkX,Y,C_jjY,C_jkY):
     Ymeans = np.nanmean(Y, axis=1)    
     Xcounts = np.array(np.sum(~np.isnan(X), axis=1),dtype=float)
     Ycounts = np.array(np.sum(~np.isnan(Y), axis=1),dtype=float)
+    XYcounts = np.array(np.sum(~np.isnan(X) & ~np.isnan(Y), axis=1),dtype=float)
+
     Xmeans[Xcounts < 2] = 0 
     Ymeans[Ycounts < 2] = 0
 
-    XYcounts = np.array(np.sum(~np.isnan(X) & ~np.isnan(Y), axis=1),dtype=float)
-    XYcovar = np.nansum((X-Xmeans[:,np.newaxis])*(Y-Ymeans[:,np.newaxis]),1,dtype=float)/(XYcounts-1) # Standard sampling covariance formula between X and Y.
+    
+    # Standard sampling covariance formula between X and Y, being careful to not divide by 0.
+    XYcovar = np.nansum((X-Xmeans[:,np.newaxis])*(Y-Ymeans[:,np.newaxis]),1,dtype=float)
     XYcovar[XYcounts <= 1] = 0  # No sampling covariance if no overlap
+    XYcovar[XYcounts > 1] = XYcovar[XYcounts > 1] / (XYcounts[XYcounts > 1]-1) # divide by dof when more than 1 observation present for both outcomes
+    
 
     tmpX = C_jkX*Xmeans[np.newaxis,:]*Xcounts[np.newaxis,:]    
     tmpY = C_jkY*Ymeans[np.newaxis,:]*Ycounts[np.newaxis,:]    
@@ -80,8 +85,11 @@ def lamb_sum_spec(X,C_jjX,C_jkX):
     Xmeans = np.nanmean(X, axis=1)
     Xcounts = np.array(np.sum(~np.isnan(X), axis=1),dtype=float)
     Xmeans[Xcounts < 2] = 0 
-    Xvar = np.nansum((X-Xmeans[:,np.newaxis])*(X-Xmeans[:,np.newaxis]),1,dtype=float)/(Xcounts-1) # Standard sampling covariance formula between X and Y.
+    
+    # Standard sampling covariance formula between X and Y, being careful to not divide by 0.
+    Xvar = np.nansum((X-Xmeans[:,np.newaxis])*(X-Xmeans[:,np.newaxis]),1,dtype=float)
     Xvar[Xcounts <= 1] = 0  # No sampling covariance if no overlap
+    Xvar[Xcounts > 1] = Xvar[Xcounts > 1] / (Xcounts[Xcounts > 1]-1) # divide by dof when more than 1 observation present for outcome
 
     tmpX = C_jkX*Xmeans[np.newaxis,:]*Xcounts[np.newaxis,:]    
     tmpBX = C_jkX*C_jkX*Xvar[np.newaxis,:]*Xcounts[np.newaxis,:]    

--- a/ustat_var/makec.py
+++ b/ustat_var/makec.py
@@ -28,16 +28,17 @@ def makec(X,Y, w=None):
     XYcounts = np.array(np.sum(~np.isnan(X) & ~np.isnan(Y), axis=1),dtype=float) # returns no. of observations across all teachers in XandY (e.g. shared observations)
     J = sum(Xcounts*Ycounts - XYcounts > 0) 
     
-    # If weights present, drop those rows with only one observation
+    # If weights present, set weights where only 1 observation to 0
     if not(w is None):
-        w = w[Xcounts*Ycounts - XYcounts > 0].copy()
+        w[Xcounts*Xcounts - Xcounts == 0] = 0
     
     # Check if weights are teacher-level and that each valid teacher has a weight.
     # Fail if not.
     if not(w is None):
+        valid_w_count = np.sum(w > 0)
         if (w.ndim != 1):
             raise ValueError("Weight object has wrong dimension. You need to supply teacher-level weights only (i.e. 1 weight per teacher). Check 'w' and try again.")
-        elif (len(w) != J):
+        elif (valid_w_count != J):
             raise ValueError("Not enough weights supplied (i.e. some teachers didn't receive weights). Check 'w' and try again.")
         
     # Compute C coefficients
@@ -92,12 +93,17 @@ def makec_spec(X, w=None):
     Xcounts = np.array(np.sum(~np.isnan(X), axis=1),dtype=float) # returns no. of observations across all teachers in X (e.g. event X)
     J = sum(Xcounts*Xcounts - Xcounts > 0) 
     
+    # If weights present, set weights where only 1 observation to 0
+    if not(w is None):
+        w[Xcounts*Xcounts - Xcounts == 0] = 0
+    
     # Check if weights are teacher-level and that each valid teacher has a weight.
     # Fail if not.
     if not(w is None):
+        valid_w_count = np.sum(w > 0)
         if (w.ndim != 1):
             raise ValueError("Weight object has wrong dimension. You need to supply teacher-level weights only (i.e. 1 weight per teacher). Check 'w' and try again.")
-        elif (len(w) != J):
+        elif (valid_w_count != J):
             raise ValueError("Not enough weights supplied (i.e. some teachers didn't receive weights). Check 'w' and try again.")
         
     # Compute C coefficients

--- a/ustat_var/makec.py
+++ b/ustat_var/makec.py
@@ -28,6 +28,10 @@ def makec(X,Y, w=None):
     XYcounts = np.array(np.sum(~np.isnan(X) & ~np.isnan(Y), axis=1),dtype=float) # returns no. of observations across all teachers in XandY (e.g. shared observations)
     J = sum(Xcounts*Ycounts - XYcounts > 0) 
     
+    # If weights present, drop those rows with only one observation
+    if not(w is None):
+        w = w[Xcounts*Ycounts - XYcounts > 0].copy()
+    
     # Check if weights are teacher-level and that each valid teacher has a weight.
     # Fail if not.
     if not(w is None):

--- a/ustat_var/makec.py
+++ b/ustat_var/makec.py
@@ -26,11 +26,12 @@ def makec(X,Y, w=None):
     Xcounts = np.array(np.sum(~np.isnan(X), axis=1),dtype=float) # returns no. of observations across all teachers in X (e.g. event X)
     Ycounts = np.array(np.sum(~np.isnan(Y), axis=1),dtype=float) # returns no. of observations across all teachers in Y (e.g. event Y)
     XYcounts = np.array(np.sum(~np.isnan(X) & ~np.isnan(Y), axis=1),dtype=float) # returns no. of observations across all teachers in XandY (e.g. shared observations)
-    J = sum(Xcounts*Ycounts - XYcounts > 0) 
+    nproducts = Xcounts * Ycounts - XYcounts # no. of valid observations (year product pairs)
+    J = sum(nproducts > 0) # Number of rows with valid observations (more than 1 product pair)
     
     # If weights present, set weights where only 1 observation to 0
     if not(w is None):
-        w[Xcounts*Xcounts - Xcounts == 0] = 0
+        w[nproducts == 0] = 0
     
     # Check if weights are teacher-level and that each valid teacher has a weight.
     # Fail if not.
@@ -44,9 +45,8 @@ def makec(X,Y, w=None):
     # Compute C coefficients
     if (w is None):
         # Unweighted (each teacher receives equal weight
-    
-        C_jj = (J-1)/J**2/(Xcounts*Ycounts - XYcounts)
-        C_jj[(Xcounts*Ycounts - XYcounts) == 0] = 0
+        C_jj = np.zeros(len(nproducts)) 
+        C_jj[nproducts > 0] = (J-1)/J**2/(nproducts[nproducts > 0]) # Divide by nproducts when there are more than 0 (avoids divide by 0 for single observation rows)
         C_jk = -1/J**2*(1/Xcounts).reshape(-1,1).dot((1/Ycounts).reshape(1,-1))    # J-by-J, with C_jk as each element.
         
         # Set those with no observations to 0
@@ -56,9 +56,9 @@ def makec(X,Y, w=None):
     else:
         # Weighted (each teacher receives weight corresponding to entries in w)
         w_norm = w / np.sum(w) # Normalised weights
-        
-        C_jj = w_norm * (1 - w_norm) * (1/(Xcounts*Ycounts - XYcounts))
-        C_jj[(Xcounts*Ycounts - XYcounts) == 0] = 0
+        C_jj = w_norm * (1 - w_norm) 
+        C_jj[nproducts == 0] = 0 # Set single observations to 0 (already 0 due to weights definition)
+        C_jj[nproducts > 0] = C_jj[nproducts > 0] / nproducts[nproducts > 0] # Divide by nproducts when there are more than 0 (avoids divide by 0 for single observation rows)
         C_jk = -(w_norm * w_norm)*(1/Xcounts).reshape(-1,1).dot((1/Ycounts).reshape(1,-1))    # J-by-J, with C_jk as each element.
         
         # Set those with no observations to 0
@@ -91,11 +91,12 @@ def makec_spec(X, w=None):
     
     # Number of observations in X, Y, and intersection
     Xcounts = np.array(np.sum(~np.isnan(X), axis=1),dtype=float) # returns no. of observations across all teachers in X (e.g. event X)
-    J = sum(Xcounts*Xcounts - Xcounts > 0) 
+    nproducts = Xcounts * Xcounts - Xcounts
+    J = sum(nproducts > 0) 
     
     # If weights present, set weights where only 1 observation to 0
     if not(w is None):
-        w[Xcounts*Xcounts - Xcounts == 0] = 0
+        w[nproducts == 0] = 0
     
     # Check if weights are teacher-level and that each valid teacher has a weight.
     # Fail if not.
@@ -109,9 +110,8 @@ def makec_spec(X, w=None):
     # Compute C coefficients
     if (w is None):
         # Unweighted (each teacher receives equal weight
-    
-        C_jj = (J-1)/J**2/(Xcounts*Xcounts - Xcounts)
-        C_jj[(Xcounts*Xcounts - Xcounts) == 0] = 0
+        C_jj = np.zeros(len(nproducts)) 
+        C_jj[nproducts > 0] = (J-1)/J**2/(nproducts[nproducts > 0]) # Divide by nproducts when there are more than 0 (avoids divide by 0 for single observation rows)
         C_jk = -1/J**2*(1/Xcounts).reshape(-1,1).dot((1/Xcounts).reshape(1,-1))    # J-by-J, with C_jk as each element.
         
         # Set those with no observations to 0
@@ -122,8 +122,9 @@ def makec_spec(X, w=None):
         # Weighted (each teacher receives weight corresponding to entries in w)
         w_norm = w / np.sum(w) # Normalised weights
         
-        C_jj = w_norm * (1 - w_norm) * (1/(Xcounts*Xcounts - Xcounts))
-        C_jj[(Xcounts*Xcounts - Xcounts) == 0] = 0
+        C_jj = w_norm * (1 - w_norm) 
+        C_jj[nproducts == 0] = 0 # Set cases with no valid product pairs to 0
+        C_jj[nproducts > 0] = C_jj[nproducts > 0] / nproducts[nproducts > 0] # Divide by nproducts when there are more than 0 (avoids divide by 0 for single observation rows)
         C_jk = -(w_norm * w_norm)*(1/Xcounts).reshape(-1,1).dot((1/Xcounts).reshape(1,-1))    # J-by-J, with C_jk as each element.
         
         # Set those with no observations to 0

--- a/ustat_var/makec.py
+++ b/ustat_var/makec.py
@@ -44,7 +44,7 @@ def makec(X,Y, w=None):
         
     # Compute C coefficients
     if (w is None):
-        # Unweighted (each teacher receives equal weight
+        # Unweighted (each teacher receives equal weight)
         C_jj = np.zeros(len(nproducts)) 
         C_jj[nproducts > 0] = (J-1)/J**2/(nproducts[nproducts > 0]) # Divide by nproducts when there are more than 0 (avoids divide by 0 for single observation rows)
         C_jk = -1/J**2*(1/Xcounts).reshape(-1,1).dot((1/Ycounts).reshape(1,-1))    # J-by-J, with C_jk as each element.

--- a/ustat_var/makec.py
+++ b/ustat_var/makec.py
@@ -5,6 +5,8 @@ import numpy as np
 def makec(X,Y, w=None):
     r"""
     Generates C-weights for U-statistic estimator.
+    The function can deal with the case when there is only one product pair across the outcomes.
+    But it cannot deal with the case when a row in either of the two arrays X and Y is completely empty.
 
     Parameters
     ----------
@@ -41,7 +43,11 @@ def makec(X,Y, w=None):
             raise ValueError("Weight object has wrong dimension. You need to supply teacher-level weights only (i.e. 1 weight per teacher). Check 'w' and try again.")
         elif (valid_w_count != J):
             raise ValueError("Not enough weights supplied (i.e. some teachers didn't receive weights). Check 'w' and try again.")
-        
+    
+    # If X or Y contains a row of emptys, fail and report to user.
+    if (np.any(Xcounts == 0)) or (np.any(Ycounts == 0)):
+            raise ValueError("One of the supplied arrays contains a completely empty row. Function does not support this. Remove those rows and try agian.")
+
     # Compute C coefficients
     if (w is None):
         # Unweighted (each teacher receives equal weight)

--- a/ustat_var/sampc.py
+++ b/ustat_var/sampc.py
@@ -21,6 +21,14 @@ def sampc(X,Y):
     Xmeans = np.nanmean(X, axis=1)
     Ymeans = np.nanmean(Y, axis=1)
     XYcounts = np.array(np.sum(~np.isnan(X) & ~np.isnan(Y), axis=1),dtype=float)
-    XYcovar = np.nansum((X-Xmeans[:,np.newaxis])*(Y-Ymeans[:,np.newaxis]),1,dtype=float)/(XYcounts-1)
+    
+    # Calculate SSE
+    XYcovar = np.nansum((X-Xmeans[:,np.newaxis])*(Y-Ymeans[:,np.newaxis]),1,dtype=float)
+    
+    # If 1 observation, SSE set to 0 
     XYcovar[XYcounts <= 1] = 0  
+    
+    # If more than 1 observation, divide by d.o.f.
+    XYcovar[XYcounts > 1] = XYcovar[XYcounts > 1] / (XYcounts[XYcounts > 1]-1)
+    
     return XYcovar

--- a/ustat_var/sampc.py
+++ b/ustat_var/sampc.py
@@ -18,6 +18,14 @@ def sampc(X,Y):
     array
         J-by-1 array containing sampling covariance between each row of X and Y.
     '''
+    # Check inputs
+    Xcounts = np.sum(~np.isnan(X), axis=1)
+    Ycounts = np.sum(~np.isnan(Y), axis=1)
+
+    # Check at least one valid observation in each row
+    if (Xcounts == 0).any() or (Ycounts == 0).any():
+        raise ValueError('Each row of X and Y must have at least one non-missing value.')
+
     Xmeans = np.nanmean(X, axis=1)
     Ymeans = np.nanmean(Y, axis=1)
     XYcounts = np.array(np.sum(~np.isnan(X) & ~np.isnan(Y), axis=1),dtype=float)

--- a/ustat_var/varcovar.py
+++ b/ustat_var/varcovar.py
@@ -66,7 +66,16 @@ def varcovar(origX, origY, w=None, quiet=True):
     X = np.nan_to_num(origX[nproducts > 0, :].copy(), 0) # Create X, which is copy of origX, though removing teachers who only have 1 observation on a specific outcome.
     Y = np.nan_to_num(origY[nproducts > 0, :].copy(), 0) # Same for Y and origY here. In  both, we replace NaNs with 0. 
     
-
+    # If weights present, drop those rows with only one observation too
+    if not(w is None):
+        w = w[nproducts > 0].copy()
+        
+    # Report back to user how many rows were dropped due to this issue
+    drop_teacher_check = np.any(nproducts == 0)
+    if (drop_teacher_check):
+        n_dropped = np.sum(nproducts == 0)
+        str(n_dropped) + " rows dropped due to only have one observation in particular row."
+        
     ## 3 Reporting ##
     # Report what type of variance calculation is being implemented.
     if (w is None):

--- a/ustat_var/varcovar.py
+++ b/ustat_var/varcovar.py
@@ -68,7 +68,7 @@ def varcovar(origX, origY, w=None, quiet=True):
     
     # If weights present, drop those rows with only one observation too
     if not(w is None):
-        w = w[nproducts > 0].copy()
+        weights = w[nproducts > 0].copy()
         
     # Report back to user how many rows were dropped due to this issue
     drop_teacher_check = np.any(nproducts == 0)

--- a/ustat_var/varcovar.py
+++ b/ustat_var/varcovar.py
@@ -74,7 +74,8 @@ def varcovar(origX, origY, w=None, quiet=True):
     drop_teacher_check = np.any(nproducts == 0)
     if (drop_teacher_check):
         n_dropped = np.sum(nproducts == 0)
-        str(n_dropped) + " rows dropped due to only have one observation in particular row."
+        if not(quiet):
+            print(str(n_dropped) + " rows dropped due to only have one observation in particular row.")
         
     ## 3 Reporting ##
     # Report what type of variance calculation is being implemented.

--- a/ustat_var/varcovar.py
+++ b/ustat_var/varcovar.py
@@ -70,9 +70,9 @@ def varcovar(origX, origY, w=None, quiet=True):
     if not(w is None):
         weights = w[nproducts > 0].copy()
         
-    # Report back to user how many rows were dropped due to this issue
-    drop_teacher_check = np.any(nproducts == 0)
-    if (drop_teacher_check):
+    # Report back to user how many rows were dropped due (if they were dropped)
+    drop_row_check = np.any(nproducts == 0)
+    if (drop_row_check):
         n_dropped = np.sum(nproducts == 0)
         if not(quiet):
             print(str(n_dropped) + " rows dropped due to only have one observation in particular row.")


### PR DESCRIPTION
# Summary

This pull request aims to fix the bug identified by Merrill Warnick (issue https://github.com/jkmulq/ustat_var/issues/1). The bug occurred when the supplied data contains rows with only one observation. The varcovar function drops those rows from the data, but those rows were kept for the weights. This causes an array dimension mismatch, and the code fails. 

This problem affects almost all functions in the module. This edge case also causes a divide by 0 issue in some of the other helper functions (`makec()`, `sampc()`, and `lamb_sum()`). This pull request fixes the drop-weights bug and adapts the code to avoid a divide by 0 warnings if it would otherwise occur. I included some unit tests to test the new functionality.

Overall, I want to make sure my changes make sense. I also want to know if there are some more robust ways to test the new weight dropping functionality.

Note, previously included tests pass.

## Other miscellaneous changes
I also made a **few cosmetic changes** to the code (e.g. cleaning up some comments, removing unnecessary module imports). I also **changed the variance summation unit test** to test on balanced-within-rows data, rather than imbalanced. The identity doesn't numerically hold for imbalanced-within-rows data.

# For review
Below I summarize what I changed, and what I think need particular attention during review.

## `varcovar()`
For `varcovar()`, I added a few lines that drop the rows where `nproducts==0`. I also added a reporting mechanism alerting the user that the rows have been dropped, which fires if the user turns off the `quiet` option.

## `ustat_samp_covar()` suite
No direct changes to these functions. The bug only affects this function through the helper functions (discussed next). 

## Helper functions
For `makec()`, `sampc()`, and `lamb_sum()` functions:
- I changed the division logic to avoid a divide by 0 if nproducts/Xcounts is 1.  
- I also added a failsafe if the user supplies an array with a row full of empties. This caused a lot of problems with the C_jk in `makec()` helper function (mostly mismatched arrays if I remove those empty rows from the calculations).

Please check that these changes make sense, and that you agree with the failsafe I included.

## Unit tests
I found it difficult to think of what types of tests would genuinely test the new functionality. I concluded that, given all the functions are written to _drop_ rows with an invalid number of observations, _then_ applying any function to the full dataset should be equivalent to applying the function to a dataset with those problematic rows already dropped. For example, `varcovar(X, X, w=w)` should be equivalent to `varcovar(X_filt, X_filt, w=w_filt)`, where `X_filt` and `w_filt` are copies of `X` and `w` but have any problematic rows dropped. 

This logic underlies all of the new unit tests:
- I am pretty happy with the new test in `test_varcovar.py`.
- I don't know if the tests I have for `test_makec.py` and `test_ustat_samp_covar.py` are robust/wide ranging enough.

Do you have any ideas of how else I could test the new functionality? Happy to include more for due diligence purposes.