### PR TITLE
varcovar_balanced

### DIFF
--- a/ustat_var/generate_test_data.py
+++ b/ustat_var/generate_test_data.py
@@ -119,5 +119,5 @@ def generate_data(n_teachers, n_time, n_arrays, var_fixed=1.0, var_noise=1.0, co
         new_array = np.random.normal(loc=_mu, scale=np.sqrt(var_noise), size=(n_teachers, n_time))
         arrays.append(new_array)
 
-    return arrays
+    return arrays, mu
 

--- a/ustat_var/varcovar.py
+++ b/ustat_var/varcovar.py
@@ -1,6 +1,5 @@
 # Dependencies:
 import numpy as np
-from scipy import sparse
 
 # U-stat estimator of variance / covariance
 def varcovar(origX, origY, w=None, quiet=True):
@@ -19,6 +18,10 @@ def varcovar(origX, origY, w=None, quiet=True):
     2 years observed.
 
     X and Y must have the same dimension.
+
+    Note, this is a warrpper function that calls varcovar_balanced or varcovar_ustat depending on whether the panels are balanced or unbalanced.
+   "varcovar_balanced.py" is used when the panels are balanced, i.e. each teacher appears the same number of times in both X and Y.
+    "varcovar_ustat.py" is used when the panels are unbalanced, i.e. each teacher appears a different number of times in X and Y.
     
     Parameters
     ----------
@@ -35,7 +38,6 @@ def varcovar(origX, origY, w=None, quiet=True):
     -------
     float
         Variance-covariance between rowmeans of origX and origY.
-
     '''
     
     ## 1 Input checks ##
@@ -50,127 +52,27 @@ def varcovar(origX, origY, w=None, quiet=True):
         weights = w
         if (weights.ndim != 1):
             ValueError("Supplied weights have strange dimension. The 'w' object needs to be an array with J elements, where J is the number of rows in A and B. Inspect and retry.")
+        
+        if np.any(weights < 0):
+            raise ValueError("Supplied weights have negative values. Please inspect and try again.")
     
     # Function does not support X_{jt} = 0 (since these are indistinguishable from NaN/missing values).
     # Raise error if 0 value detected.
     if (np.sum(origX == 0) != 0) | (np.sum(origY == 0) != 0):
         raise ValueError("Supplied data has at least 1 data point which =0. 0 data points are not supported. Please inspect and try again.")
     
+    # check that each teacher appear at least 2 times in each matrix
+    if (origX.shape[1] < 2) | (origY.shape[1] < 2):
+        raise ValueError("At least one teacher must appear at least 2 times in each matrix. Please inspect and try again.")
     
-    ## 2 Compute necessary values ## 
-    # Counds of valid obs
-    countsX = np.count_nonzero(~np.isnan(origX),1)  # No. of obs in X
-    countsY = np.count_nonzero(~np.isnan(origY),1)  # No. of obs in Y
-    nsquares = np.count_nonzero(~np.isnan(origX * origY),1)   # No. of obs in both X and Y
-    nproducts = (countsX*countsY - nsquares) # No. of valid product pairs
-    X = np.nan_to_num(origX[nproducts > 0, :].copy(), 0) # Create X, which is copy of origX, though removing teachers who only have 1 observation on a specific outcome.
-    Y = np.nan_to_num(origY[nproducts > 0, :].copy(), 0) # Same for Y and origY here. In  both, we replace NaNs with 0. 
-    
-    # If weights present, drop those rows with only one observation too
-    if not(w is None):
-        weights = w[nproducts > 0].copy()
-        
-    # Report back to user how many rows were dropped due (if they were dropped)
-    drop_row_check = np.any(nproducts == 0)
-    if (drop_row_check):
-        n_dropped = np.sum(nproducts == 0)
-        if not(quiet):
-            print(str(n_dropped) + " rows dropped due to having no valid observations across both outcomes.")
-        
-    ## 3 Reporting ##
-    # Report what type of variance calculation is being implemented.
-    if (w is None):
-        calc_type = "unweighted"
-        
-    elif not(w is None):
-        calc_type = "weighting by rows"
-    
-    # Report whether panels are balanced/unbalanced
+    # Check if panels are balanced/unbalanced
     check_balance = np.sum((np.isnan(origX) == np.isnan(origY)).all())
     if check_balance == 1:
-        panel_type = "balanced within-teacher"
+        Ustat_estimate = varcovar_balanced(origX, origY, w, quiet)
     else:
-        panel_type = "unbalanced within- and between-teachers"
+        Ustat_estimate = varcovar_ustat(origX, origY, w, quiet)
     
-    # Tell user type of calculation/observed panel type
-    if not(quiet):
-        report_message = "Panels are \033[1m" + panel_type + "\033[0m \n Calculating variance by \033[1m" + calc_type + "\033[0m..."
-        print(report_message)
-    
-    ## 4 Calculation ##
-    
-    # 4.1 Calculate second term
-    
-    if not(w is None):
-        # User-supplied teacher weights option.
-        
-        # Computed unweighted teacher means Mu
-        X_means = np.nanmean(origX[nproducts > 0, :], 1)
-        Y_means = np.nanmean(origY[nproducts > 0, :], 1)
-        
-        # Weight Mu by teacher weights
-        X_means = (weights / np.nansum(weights)) * X_means 
-        Y_means = (weights / np.nansum(weights)) * Y_means
-        
-        # Take products, remove j = k case, and sum up
-        tmp = X_means.reshape(-1,1).dot(Y_means.reshape(1,-1))
-        np.fill_diagonal(tmp,0)
-        gmean = np.sum(tmp)
-        
-    else:
-        # Unweighted option
-        
-        # Unweighted teacher mean
-        X_means = np.nanmean(origX[nproducts > 0, :],1) 
-        Y_means = np.nanmean(origY[nproducts > 0, :],1)
-        
-        # Take products, removing j = k case and sum up
-        tmp = X_means.reshape(-1,1).dot(Y_means.reshape(1,-1)) # Take X_means' %*% Y_means.
-        np.fill_diagonal(tmp,0)
-        gmean = np.sum(tmp) / (len(X_means)*len(Y_means)) 
+    return Ustat_estimate
 
-
-    # 4.2 Calculate first term
-    # Diagonalizied sparse matrix for taking products (columns of diag X will replicate a row of X, with the remaining elements in the column being 0)
-    diagX = sparse.csr_matrix(
-            (X.ravel(),
-            (np.arange(X.shape[0]*X.shape[1]),
-            np.repeat(np.arange(X.shape[0]),X.shape[1]))
-            ))
-
-    # Generate all teacher-year product pairs (The resulting product will have the mean teacher residual in time t from X multiplied by the mean teacher residual in time t from Y.
-    k = diagX.dot(sparse.csr_matrix(Y))
-    
-    # Create matrix to help take sums within teacher of the 'k' matrix.
-    teach_sum = sparse.csr_matrix(
-            (np.ones(X.shape[0]*X.shape[1]),
-                (np.arange(X.shape[0]*X.shape[1]),
-                np.repeat(np.arange(X.shape[0]),X.shape[1]))
-                ))
-    
-    # This multiplication sums up the products for each teacher, which will yield the total sum of the product of mean residuals across all pairs of years.
-    sums = teach_sum.T.dot(np.sum(k,1))
-    sums = (sums - np.nansum(X * Y, 1)[:,np.newaxis]) # Subtract the t=t product pairs.
-    
-    # Divide by no. of teacher-year product pairs
-    sums = sums.ravel()/nproducts[nproducts > 0]
-    
-    
-    # Calculate appropriate mean of means
-    if not(w is None):
-        # Weighted variance option
-        w_norm = weights / np.sum(weights)
-        _weights = w_norm * (1 - w_norm)
-        sums = np.array(sums) * np.array(_weights)
-        Ustat = np.sum(sums) - gmean
-        
-    else:
-        # Unweighted option
-        Ustat = (len(X_means)-1)/len(X_means)*np.mean(sums) - gmean
-    
-    
-    ## 5 Return sampling vairance estimate ##
-    return Ustat
-    
 
     

--- a/ustat_var/varcovar_balanced.py
+++ b/ustat_var/varcovar_balanced.py
@@ -1,0 +1,109 @@
+# Dependencies
+import numpy as np
+
+
+def varcovar_balanced(origX,origY, w = None, quiet = False, homoskedastic_noise = False):
+
+    # Check if user supplied weights.
+    # If they exist, describe what type of weights they are
+    if not(w is None):
+        weights = w
+        if (weights.ndim != 1):
+            ValueError("Supplied weights have strange dimension. The 'w' object needs to be an array with J elements, where J is the number of rows in A and B. Inspect and retry.")
+        
+        if np.any(weights < 0):
+            raise ValueError("Supplied weights have negative values. Please inspect and try again.")
+    
+    ## 1 Input checks ##
+    # Check if X, Y have observations
+    if (len(origX) == 0) | (len(origY) == 0):
+        print('No observations in X or Y matrices')
+        return np.nan
+    
+    # Function does not support X_{jt} = 0 (since these are indistinguishable from NaN/missing values).
+    # Raise error if 0 value detected.
+    if (np.sum(origX == 0) != 0) | (np.sum(origY == 0) != 0):
+        raise ValueError("Supplied data has at least 1 data point which =0. 0 data points are not supported. Please inspect and try again.")
+    
+    # check that each teacher appear at least 2 times in each matrix
+    if (origX.shape[1] < 2) | (origY.shape[1] < 2):
+        raise ValueError("At least one teacher must appear at least 2 times in each matrix. Please inspect and try again.")
+
+    # Impose that both "Y" and "X" outcomes appear in year "t" --- this is needed here but not in the U-stat version
+    #   check if this is the case and if not impose it
+    check_balance = np.sum((np.isnan(origX) == np.isnan(origY)).all())
+    if (check_balance == 0):
+        unbalanced_teachers = ((np.isnan(origX) == np.isnan(origY)) == False).sum(axis=1)
+        # keep only teachers that appear in both X and Y
+        origX = origX[np.where(unbalanced_teachers==0), :] 
+        origY = origY[np.where(unbalanced_teachers==0), :]
+    check_balance = np.sum((np.isnan(origX) == np.isnan(origY)).all())
+    assert check_balance == 1
+
+    ## 2 Compute necessary values ## 
+    # Counds of valid obs
+    countsX = np.count_nonzero(~np.isnan(origX),1)  # No. of obs in X
+    countsY = np.count_nonzero(~np.isnan(origY),1)  # No. of obs in Y
+    nsquares = np.count_nonzero(~np.isnan(origX * origY),1)   # No. of obs in both X and Y
+    nproducts = (countsX*countsY - nsquares) # No. of valid product pairs
+    X = np.nan_to_num(origX[nproducts > 0, :].copy(), 0) # Create X, which is copy of origX, though removing teachers who only have 1 observation on a specific outcome.
+    Y = np.nan_to_num(origY[nproducts > 0, :].copy(), 0) # Same for Y and origY here. In  both, we replace NaNs with 0. 
+    
+    # If weights present, drop those rows with only one observation too
+    if not(w is None):
+        weights = w[nproducts > 0].copy()
+        
+    # Report back to user how many rows were dropped due (if they were dropped)
+    drop_row_check = np.any(nproducts == 0)
+    if (drop_row_check):
+        n_dropped = np.sum(nproducts == 0)
+        if not(quiet):
+            print(str(n_dropped) + " rows dropped due to having no valid observations across both outcomes.")
+    
+    J = X.shape[0]# total number of teachers
+
+    if (len(X) == 0) | (len(Y) == 0):
+        print('No observations in X or Y vectors')
+        return np.nan
+
+    # Calculate within-teacher covariances
+    Xdemeans = X - (X.sum(axis=1)/np.count_nonzero(X, axis=1))[:,np.newaxis]
+    Xdemeans = Xdemeans * (X!=0)
+    Ydemeans = Y - (Y.sum(axis=1)/np.count_nonzero(Y, axis=1))[:,np.newaxis]
+    Ydemeans = Ydemeans * (Y!=0)
+    covs_j = (Xdemeans*Ydemeans).sum(axis=1)/(np.count_nonzero(X, axis=1)-1)
+    covs_j = covs_j/np.count_nonzero(X, axis=1) 
+
+    if homoskedastic_noise:
+        covs_homo = (Xdemeans*Ydemeans).sum()/(np.count_nonzero(X)-1)
+        covs_j_homo = covs_homo/np.count_nonzero(X, axis=1)
+
+    # Calculate ACROSS teacher covariance
+    Xmeans = X.sum(axis=1)/np.count_nonzero(X, axis=1)
+    Ymeans = Y.sum(axis=1)/np.count_nonzero(Y, axis=1)
+    
+    if not(w is None):
+        weights_norm = weights / np.sum(weights)
+        Xmeans = Xmeans - (Xmeans*weights_norm).sum()
+        Ymeans = Ymeans - (Ymeans*weights_norm).sum()
+        for_covs_across = Xmeans * Ymeans
+        covs_across = (for_covs_across*weights_norm).sum()
+        sampling_var = (covs_j*weights_norm*(1-weights_norm)).sum()
+    else:
+        Xmeans = Xmeans - Xmeans.sum()/J    
+        Ymeans = Ymeans - Ymeans.sum()/J
+        covs_across = (Xmeans * Ymeans).sum()/J
+        covs_j = covs_j*(1-1/J)
+        sampling_var = covs_j.sum()/J
+    
+    if homoskedastic_noise:
+        if not(w is None):
+            sampling_var_homo = (covs_j_homo*weights_norm*(1-weights_norm)).sum()
+        else:
+            covs_j_homo = covs_j_homo*(1-1/J)
+            sampling_var_homo = covs_j_homo.sum()/J
+        debias_varcovar = covs_across - sampling_var_homo
+    else:
+        debias_varcovar = covs_across - sampling_var
+
+    return debias_varcovar

--- a/ustat_var/varcovar_ustat.py
+++ b/ustat_var/varcovar_ustat.py
@@ -1,0 +1,182 @@
+# Dependencies:
+import numpy as np
+from scipy import sparse
+
+# U-stat estimator of variance / covariance
+def varcovar(origX, origY, w=None, quiet=True):
+    r'''
+    U-stat estimator of variance / covariance for teacher effects
+    X and Y are a J-by-:math:`\operatorname{max}(T_j)` matrix of teacher-specific mean residuals. 
+    When X and Y are residuals for the same outcome and covariate group,
+    code will return a estimate of variance of teacher effects. When X and Y
+    differ (either in outcome or Xs), code returns an estimate of the 
+    covariance. 
+
+    Each row of X and Y are residuals for a specific teacher, ordered as
+    first year observed, second year observed, etc. Since teachers have
+    different number of years observed, X and Y should be np.NaN for all
+    years after the last year observed. Each teacher must have at least
+    2 years observed.
+
+    X and Y must have the same dimension.
+    
+    Parameters
+    ----------
+    origX: array
+        J-by-:math:`\operatorname{max}(T_j)` array containing residuals/data for outcome X
+    origY: array
+        J-by-:math:`\operatorname{max}(T_j)` array containing residuals/data for outcome Y
+    w: array
+        (Optional) J-by-1 array of user-supplied weights. If supplied, varcovar will return row-weighted variance-covariance of row means. 
+    quiet: boolean
+        (Optional) If quiet=True, function call will report type of variance being calculated (unweighted/weighted) and whether panels are balanced or unbalanced.
+
+    Returns
+    -------
+    float
+        Variance-covariance between rowmeans of origX and origY.
+
+    '''
+    
+    ## 1 Input checks ##
+    # Check if X, Y have observations
+    if (len(origX) == 0) | (len(origY) == 0):
+        print('No observations in X or Y matrices')
+        return np.nan
+    
+    # Check if user supplied weights.
+    # If they exist, describe what type of weights they are
+    if not(w is None):
+        weights = w
+        if (weights.ndim != 1):
+            ValueError("Supplied weights have strange dimension. The 'w' object needs to be an array with J elements, where J is the number of rows in A and B. Inspect and retry.")
+        
+        if np.any(weights < 0):
+            raise ValueError("Supplied weights have negative values. Please inspect and try again.")
+    
+    # Function does not support X_{jt} = 0 (since these are indistinguishable from NaN/missing values).
+    # Raise error if 0 value detected.
+    if (np.sum(origX == 0) != 0) | (np.sum(origY == 0) != 0):
+        raise ValueError("Supplied data has at least 1 data point which =0. 0 data points are not supported. Please inspect and try again.")
+    
+    # check that each teacher appear at least 2 times in each matrix
+    if (origX.shape[1] < 2) | (origY.shape[1] < 2):
+        raise ValueError("At least one teacher must appear at least 2 times in each matrix. Please inspect and try again.")
+    
+    ## 2 Compute necessary values ## 
+    # Counds of valid obs
+    countsX = np.count_nonzero(~np.isnan(origX),1)  # No. of obs in X
+    countsY = np.count_nonzero(~np.isnan(origY),1)  # No. of obs in Y
+    nsquares = np.count_nonzero(~np.isnan(origX * origY),1)   # No. of obs in both X and Y
+    nproducts = (countsX*countsY - nsquares) # No. of valid product pairs
+    X = np.nan_to_num(origX[nproducts > 0, :].copy(), 0) # Create X, which is copy of origX, though removing teachers who only have 1 observation on a specific outcome.
+    Y = np.nan_to_num(origY[nproducts > 0, :].copy(), 0) # Same for Y and origY here. In  both, we replace NaNs with 0. 
+    
+    # If weights present, drop those rows with only one observation too
+    if not(w is None):
+        weights = w[nproducts > 0].copy()
+        
+    # Report back to user how many rows were dropped due (if they were dropped)
+    drop_row_check = np.any(nproducts == 0)
+    if (drop_row_check):
+        n_dropped = np.sum(nproducts == 0)
+        if not(quiet):
+            print(str(n_dropped) + " rows dropped due to having no valid observations across both outcomes.")
+        
+    ## 3 Reporting ##
+    # Report what type of variance calculation is being implemented.
+    if (w is None):
+        calc_type = "unweighted"
+        
+    elif not(w is None):
+        calc_type = "weighting by rows"
+    
+    # Report whether panels are balanced/unbalanced
+    check_balance = np.sum((np.isnan(origX) == np.isnan(origY)).all())
+    if check_balance == 1:
+        panel_type = "balanced within-teacher"
+    else:
+        panel_type = "unbalanced within- and between-teachers"
+    
+    # Tell user type of calculation/observed panel type
+    if not(quiet):
+        report_message = "Panels are \033[1m" + panel_type + "\033[0m \n Calculating variance by \033[1m" + calc_type + "\033[0m..."
+        print(report_message)
+    
+    ## 4 Calculation ##
+    
+    # 4.1 Calculate second term
+    
+    if not(w is None):
+        # User-supplied teacher weights option.
+        
+        # Computed unweighted teacher means Mu
+        X_means = np.nanmean(origX[nproducts > 0, :], 1)
+        Y_means = np.nanmean(origY[nproducts > 0, :], 1)
+        
+        # Weight Mu by teacher weights
+        X_means = (weights / np.nansum(weights)) * X_means 
+        Y_means = (weights / np.nansum(weights)) * Y_means
+        
+        # Take products, remove j = k case, and sum up
+        tmp = X_means.reshape(-1,1).dot(Y_means.reshape(1,-1))
+        np.fill_diagonal(tmp,0)
+        gmean = np.sum(tmp)
+        
+    else:
+        # Unweighted option
+        
+        # Unweighted teacher mean
+        X_means = np.nanmean(origX[nproducts > 0, :],1) 
+        Y_means = np.nanmean(origY[nproducts > 0, :],1)
+        
+        # Take products, removing j = k case and sum up
+        tmp = X_means.reshape(-1,1).dot(Y_means.reshape(1,-1)) # Take X_means' %*% Y_means.
+        np.fill_diagonal(tmp,0)
+        gmean = np.sum(tmp) / (len(X_means)*len(Y_means)) 
+
+
+    # 4.2 Calculate first term
+    # Diagonalizied sparse matrix for taking products (columns of diag X will replicate a row of X, with the remaining elements in the column being 0)
+    diagX = sparse.csr_matrix(
+            (X.ravel(),
+            (np.arange(X.shape[0]*X.shape[1]),
+            np.repeat(np.arange(X.shape[0]),X.shape[1]))
+            ))
+
+    # Generate all teacher-year product pairs (The resulting product will have the mean teacher residual in time t from X multiplied by the mean teacher residual in time t from Y.
+    k = diagX.dot(sparse.csr_matrix(Y))
+    
+    # Create matrix to help take sums within teacher of the 'k' matrix.
+    teach_sum = sparse.csr_matrix(
+            (np.ones(X.shape[0]*X.shape[1]),
+                (np.arange(X.shape[0]*X.shape[1]),
+                np.repeat(np.arange(X.shape[0]),X.shape[1]))
+                ))
+    
+    # This multiplication sums up the products for each teacher, which will yield the total sum of the product of mean residuals across all pairs of years.
+    sums = teach_sum.T.dot(np.sum(k,1))
+    sums = (sums - np.nansum(X * Y, 1)[:,np.newaxis]) # Subtract the t=t product pairs.
+    
+    # Divide by no. of teacher-year product pairs
+    sums = sums.ravel()/nproducts[nproducts > 0]
+    
+    
+    # Calculate appropriate mean of means
+    if not(w is None):
+        # Weighted variance option
+        w_norm = weights / np.sum(weights)
+        _weights = w_norm * (1 - w_norm)
+        sums = np.array(sums) * np.array(_weights)
+        Ustat = np.sum(sums) - gmean
+        
+    else:
+        # Unweighted option
+        Ustat = (len(X_means)-1)/len(X_means)*np.mean(sums) - gmean
+    
+    
+    ## 5 Return sampling vairance estimate ##
+    return Ustat
+    
+
+    


### PR DESCRIPTION
1. Added varcovar_balanced function (varcovar_balanced.py): Based on Equation 5; faster than the U-statistic approach for balanced panels. Supports weighted estimation via the w parameter (row/teacher-level weights).
Includes homoskedastic_noise (default False) to assume homoskedastic noise instead of heteroskedastic.
Requires balanced panels: NaN patterns must match between X and Y for all positions (same missing data pattern across both matrices).

2. Renamed original function: Renamed varcovar to varcovar_ustat (in varcovar_ustat.py).
Handles unbalanced panels where teachers have different numbers of observations or different missing data patterns.

3. Created wrapper function:
varcovar in varcovar.py is now a wrapper that routes to the appropriate implementation.
Automatically detects balanced vs. unbalanced panels by checking if NaN patterns match between X and Y.
If balanced (all NaN positions match): calls varcovar_balanced.
If unbalanced: calls varcovar_ustat.
Preserves the original API, so existing code using varcovar continues to work.

4. Note: The wrapper does not currently expose the homoskedastic_noise parameter from varcovar_balanced. To use homoskedastic noise, call varcovar_balanced directly.

5. I did checks and the varcovar_balanced gives the same estimates as the U-stat (when homoskedastic_noise is False). 